### PR TITLE
feat: Add L1/L2 regularization to neural network training

### DIFF
--- a/lib/qoa/neural_network.rb
+++ b/lib/qoa/neural_network.rb
@@ -10,9 +10,9 @@ module Qoa
     include Utils
     include LossFunctions
 
-    attr_reader :input_nodes, :hidden_layers, :output_nodes, :learning_rate, :activation_func, :dropout_rate, :decay_rate, :epsilon, :batch_size
+    attr_reader :input_nodes, :hidden_layers, :output_nodes, :learning_rate, :activation_func, :dropout_rate, :decay_rate, :epsilon, :batch_size, :l1_lambda, :l2_lambda
 
-    def initialize(input_nodes, hidden_layers, output_nodes, learning_rate, dropout_rate, activation_func = :sigmoid, decay_rate = 0.9, epsilon = 1e-8, batch_size = 10)
+    def initialize(input_nodes, hidden_layers, output_nodes, learning_rate, dropout_rate, activation_func = :sigmoid, decay_rate = 0.9, epsilon = 1e-8, batch_size = 10, l1_lambda = 0.0, l2_lambda = 0.0)
       @input_nodes = input_nodes
       @hidden_layers = hidden_layers
       @output_nodes = output_nodes
@@ -22,6 +22,8 @@ module Qoa
       @decay_rate = decay_rate
       @epsilon = epsilon
       @batch_size = batch_size
+      @l1_lambda = l1_lambda
+      @l2_lambda = l2_lambda
 
       @layers = []
       @layers << Layer.new(input_nodes, hidden_layers[0])

--- a/lib/qoa/training.rb
+++ b/lib/qoa/training.rb
@@ -44,7 +44,8 @@ module Qoa
 
       # Update weights
       @layers.each_with_index do |layer, i|
-        layer.weights = matrix_add(layer.weights, scalar_multiply(@learning_rate / batch.size, weight_deltas[i]))
+        regularization_penalty = calculate_regularization_penalty(layer.weights, @l1_lambda, @l2_lambda)
+        layer.weights = matrix_add(layer.weights, scalar_multiply(@learning_rate / batch.size, matrix_add(weight_deltas[i], regularization_penalty)))
       end
     end
 
@@ -108,6 +109,17 @@ module Qoa
       end
 
       weight_deltas
+    end
+
+    def calculate_regularization_penalty(weights, l1_lambda, l2_lambda)
+      l1_penalty = weights.map do |row|
+        row.nil? ? nil : row.map { |x| x.nil? ? nil : (x < 0 ? -1 : 1) }
+      end
+      l1_penalty = scalar_multiply(l1_lambda, l1_penalty)
+
+      l2_penalty = scalar_multiply(l2_lambda, weights)
+
+      matrix_add(l1_penalty, l2_penalty)
     end
   end
 end


### PR DESCRIPTION
This commit modifies the neural_network.rb code to add L1/L2 regularization parameters to the initialize method. The training.rb code is also modified to add a calculate_regularization_penalty method, which calculates penalization matrices from the weights using L1/L2 regularization. This is used to update layer weights during training.