### PR TITLE
feat: add validation methods for constructor arguments, query arguments etc

### DIFF
--- a/lib/qoa/err/validations.rb
+++ b/lib/qoa/err/validations.rb
@@ -1,0 +1,27 @@
+module Qoa
+  module Err
+    module Validations
+      def validate_constructor_args(input_nodes, hidden_layers, output_nodes, learning_rate, dropout_rate, activation_func, decay_rate, epsilon, batch_size, l1_lambda, l2_lambda)
+        raise ArgumentError, 'input_nodes, hidden_layers, and output_nodes must be positive integers' unless [input_nodes, output_nodes].all? { |x| x.is_a?(Integer) && x > 0 } && hidden_layers.is_a?(Array) && hidden_layers.all? { |x| x.is_a?(Integer) && x > 0 }
+        raise ArgumentError, 'learning_rate, dropout_rate, decay_rate, epsilon, l1_lambda, and l2_lambda must be positive numbers' unless [learning_rate, dropout_rate, decay_rate, epsilon, l1_lambda, l2_lambda].all? { |x| x.is_a?(Numeric) && x >= 0 }
+        raise ArgumentError, 'activation_func must be a valid symbol' unless ActivationFunctions.methods.include?(activation_func)
+        raise ArgumentError, 'batch_size must be a positive integer' unless batch_size.is_a?(Integer) && batch_size > 0
+      end
+
+      def validate_query_args(inputs)
+        raise ArgumentError, 'inputs must be an array of numbers' unless inputs.is_a?(Array) && inputs.all? { |x| x.is_a?(Numeric) }
+      end
+
+      def validate_calculate_loss_args(inputs, targets, loss_function)
+        raise ArgumentError, 'inputs and targets must have the same length' if inputs.size != targets.size
+        raise ArgumentError, 'inputs and targets must be arrays of arrays of numbers' unless inputs.is_a?(Array) && targets.is_a?(Array) && inputs.all? { |x| x.is_a?(Array) && x.all? { |y| y.is_a?(Numeric) } } && targets.all? { |x| x.is_a?(Array) && x.all? { |y| y.is_a?(Numeric) } }
+        raise ArgumentError, 'loss_function must be a valid symbol' unless LossFunctions.methods.include?(loss_function)
+      end
+
+      def validate_train_args(inputs, targets)
+        raise ArgumentError, 'inputs and targets must have the same length' if inputs.size != targets.size
+        raise ArgumentError, 'inputs and targets must be arrays of arrays of numbers' unless inputs.is_a?(Array) && targets.is_a?(Array) && inputs.all? { |x| x.is_a?(Array) && x.all? { |y| y.is_a?(Numeric) } } && targets.all? { |x| x.is_a?(Array) && x.all? { |y| y.is_a?(Numeric) } }
+      end
+    end
+  end
+end

--- a/lib/qoa/neural_network.rb
+++ b/lib/qoa/neural_network.rb
@@ -3,16 +3,20 @@ require_relative 'activation_functions'
 require_relative 'training'
 require_relative 'utils'
 require_relative 'loss_functions'
+require_relative 'err/validations'
 
 module Qoa
   class NeuralNetwork
     include Training
     include Utils
     include LossFunctions
+    include Err::Validations
 
     attr_reader :input_nodes, :hidden_layers, :output_nodes, :learning_rate, :activation_func, :dropout_rate, :decay_rate, :epsilon, :batch_size, :l1_lambda, :l2_lambda
 
     def initialize(input_nodes, hidden_layers, output_nodes, learning_rate, dropout_rate, activation_func = :sigmoid, decay_rate = 0.9, epsilon = 1e-8, batch_size = 10, l1_lambda = 0.0, l2_lambda = 0.0)
+      validate_constructor_args(input_nodes, hidden_layers, output_nodes, learning_rate, dropout_rate, activation_func, decay_rate, epsilon, batch_size, l1_lambda, l2_lambda)
+
       @input_nodes = input_nodes
       @hidden_layers = hidden_layers
       @output_nodes = output_nodes
@@ -34,12 +38,14 @@ module Qoa
     end
 
     def query(inputs)
+      validate_query_args(inputs)
+
       layer_outputs = forward_pass(inputs)
       layer_outputs.last.flatten
     end
 
     def calculate_loss(inputs, targets, loss_function = :mean_squared_error)
-      raise ArgumentError, 'inputs and targets must have the same length' if inputs.size != targets.size
+      validate_calculate_loss_args(inputs, targets, loss_function)
 
       total_loss = 0.0
       inputs.zip(targets).each do |input, target|

--- a/lib/qoa/training.rb
+++ b/lib/qoa/training.rb
@@ -1,12 +1,14 @@
-require_relative 'matrix_helpers'
 require 'concurrent'
+require_relative 'matrix_helpers'
+require_relative 'err/validations'
 
 module Qoa
   module Training
     include MatrixHelpers
+    include Err::Validations
 
     def train(inputs, targets)
-      raise ArgumentError, 'inputs and targets must have the same length' if inputs.size != targets.size
+      validate_train_args(inputs, targets)
 
       inputs.zip(targets).each_slice(@batch_size) do |batch|
         train_batch(batch)


### PR DESCRIPTION
Added three new validation methods validate_constructor_args, validate_query_args, validate_calculate_loss_args which check the validity of constructor arguments, query arguments, and loss calculation arguments respectively. These methods are used in the respective methods in NeuralNetwork to validate the arguments before proceeding further.